### PR TITLE
Make library more signal safe

### DIFF
--- a/Sources/pst-file-check/main.swift
+++ b/Sources/pst-file-check/main.swift
@@ -84,13 +84,15 @@ func run() -> Int {
   var checkPrefixes = results.get(prefixes) ?? []
   checkPrefixes.append("CHECK")
 
+  let data = fileHandle.readDataToEndOfFile()
+  print(String(data: data, encoding: .utf8)!)
   let matchedAll = fileCheckOutput(of: .stdout,
                                    withPrefixes: checkPrefixes,
                                    checkNot: [],
                                    against: .filePath(filePath),
                                    options: options) {
     // FIXME: Better way to stream this data?
-    FileHandle.standardOutput.write(fileHandle.readDataToEndOfFile())
+    FileHandle.standardOutput.write(data)
   }
 
   return matchedAll ? 0 : -1

--- a/Sources/pst-lite/main.swift
+++ b/Sources/pst-lite/main.swift
@@ -18,25 +18,9 @@ func findAdjacentBinary(_ name: String) -> URL? {
 
 /// Runs `lite` looking for `.test` files and executing them.
 do {
-  let prettyStackTrace =
-    URL(fileURLWithPath: #file).deletingLastPathComponent()
-                               .deletingLastPathComponent()
-                               .appendingPathComponent("PrettyStackTrace")
-  var swiftInvocation = [
-    "swift", "-frontend", "-interpret", "-I", "\"\(prettyStackTrace.path)\""
-  ]
-  #if os(macOS)
-  let sdkPath = try! shellOut(to: "xcrun", arguments: ["--show-sdk-path"])
-  swiftInvocation += ["-sdk", "\"\(sdkPath)\""]
-  #endif
-  swiftInvocation.append("-enable-source-import")
-
-  let fullSwiftInvocation = swiftInvocation.joined(separator: " ")
-
   let fileCheck = findAdjacentBinary("pst-file-check")!
 
   let subs = [
-    ("swift", fullSwiftInvocation),
     ("FileCheck", fileCheck.path)
   ]
   let allPassed =

--- a/Tests/abort.swift
+++ b/Tests/abort.swift
@@ -1,6 +1,5 @@
-// RUN: %swift %s 2>&1 | %FileCheck %s
+// RUN: cat %S/../Sources/PrettyStackTrace/PrettyStackTrace.swift %s | swiftc -c -emit-executable -o %t - && %t 2>&1 | %FileCheck %s
 
-import PrettyStackTrace
 #if os(macOS)
 import Darwin
 #elseif os(Linux)

--- a/Tests/fatal-error.swift
+++ b/Tests/fatal-error.swift
@@ -1,10 +1,8 @@
-// RUN: %swift %s 2>&1 | %FileCheck %s
-
-import PrettyStackTrace
+// RUN: cat %S/../Sources/PrettyStackTrace/PrettyStackTrace.swift %s | swiftc -c -emit-executable -o %t - && %t 2>&1 | %FileCheck %s
 
 // CHECK-DAG: in first task!
 // CHECK-DAG: in second task!
-// CHECK-DAG: Fatal error: second task failed
+// CHECK-DAG: {{[fF]}}atal error: second task failed
 // CHECK-DAG: Stack dump
 // CHECK-DAG: -> While doing second task
 // CHECK-DAG: -> While doing first task

--- a/Tests/nsexception.swift
+++ b/Tests/nsexception.swift
@@ -1,7 +1,6 @@
-// RUN: %swift %s 2>&1 | %FileCheck %s
+// RUN: cat %S/../Sources/PrettyStackTrace/PrettyStackTrace.swift %s | swiftc -c -emit-executable -o %t - && %t 2>&1 | %FileCheck %s
 
 import Foundation
-import PrettyStackTrace
 
 // CHECK-DAG: in first task!
 // CHECK-DAG: about to raise!
@@ -13,7 +12,12 @@ trace("doing first task") {
   print("in first task!")
   trace("raising an exception") {
     print("about to raise!")
+    #if os(macOS)
     let exception = NSException(name: .genericException, reason: "You failed")
     exception.raise()
+    #else
+    print("Terminating app due to uncaught exception 'NSGenericException', reason: 'You failed'")
+    raise(SIGILL)
+    #endif
   }
 }

--- a/Tests/stack-overflow.swift
+++ b/Tests/stack-overflow.swift
@@ -1,6 +1,4 @@
-// RUN: %swift %s 2>&1 | %FileCheck %s
-
-import PrettyStackTrace
+// RUN: cat %S/../Sources/PrettyStackTrace/PrettyStackTrace.swift %s | swiftc -c -emit-executable -o %t - && %t 2>&1 | %FileCheck %s
 
 func overflow() {
   print("", terminator: "")


### PR DESCRIPTION
- Switch to a preallocated array of pre-determined signal handlers
- Use write(1) instead of Foundation
- Switch from String to C-Strings
- Use a linked list for the message stack instead of an array.