### PR TITLE
Add numbering to stack dump entries

### DIFF
--- a/Sources/PrettyStackTrace/PrettyStackTrace.swift
+++ b/Sources/PrettyStackTrace/PrettyStackTrace.swift
@@ -79,7 +79,7 @@ let numberBuffer: UnsafeMutablePointer<Int8> = {
 /// doesn't write outside the bounds of the buffer.
 /// It then writes the contents of this buffer, starting at the first space at
 /// the beginning, to stderr.
-func writeInt(_ int: UInt) {
+private func writeLeadingSpacesAndStackPosition(_ int: UInt) {
   // We can't write more than 8 digits.
   guard int <= 99_999_999 else { return }
   var int = int
@@ -166,7 +166,7 @@ private class PrettyStackTraceManager {
     var i: UInt = 1
     var cur = stack
     while cur != nil {
-      writeInt(i)
+      writeLeadingSpacesAndStackPosition(i)
       let entry = cur.unsafelyUnwrapped
       write(STDERR_FILENO, entry.pointee.data, entry.pointee.count)
       cur = entry.pointee.prev

--- a/Tests/abort.swift
+++ b/Tests/abort.swift
@@ -9,7 +9,7 @@ import Glibc
 // CHECK-DAG: in first task!
 // CHECK-DAG: in second task!
 // CHECK-DAG: Stack dump
-// CHECK-DAG: -> While doing first task
+// CHECK-DAG:   1. While doing first task
 trace("doing first task") {
   print("in first task!")
   trace("doing second task") {

--- a/Tests/fatal-error.swift
+++ b/Tests/fatal-error.swift
@@ -4,8 +4,8 @@
 // CHECK-DAG: in second task!
 // CHECK-DAG: {{[fF]}}atal error: second task failed
 // CHECK-DAG: Stack dump
-// CHECK-DAG: -> While doing second task
-// CHECK-DAG: -> While doing first task
+// CHECK-DAG:   1. While doing second task
+// CHECK-DAG:   2. While doing first task
 trace("doing first task") {
   print("in first task!")
   trace("doing second task") {

--- a/Tests/long-trace.swift
+++ b/Tests/long-trace.swift
@@ -1,0 +1,111 @@
+// RUN: cat %S/../Sources/PrettyStackTrace/PrettyStackTrace.swift %s | swiftc -c -emit-executable -o %t - && %t 2>&1 | %FileCheck %s
+
+// CHECK-DAG: Stack dump
+// CHECK-DAG:  1. While in frame 100
+// CHECK-DAG:  2. While in frame 99
+// CHECK-DAG:  3. While in frame 98
+// CHECK-DAG:  4. While in frame 97
+// CHECK-DAG:  5. While in frame 96
+// CHECK-DAG:  6. While in frame 95
+// CHECK-DAG:  7. While in frame 94
+// CHECK-DAG:  8. While in frame 93
+// CHECK-DAG:  9. While in frame 92
+// CHECK-DAG:  10. While in frame 91
+// CHECK-DAG:  11. While in frame 90
+// CHECK-DAG:  12. While in frame 89
+// CHECK-DAG:  13. While in frame 88
+// CHECK-DAG:  14. While in frame 87
+// CHECK-DAG:  15. While in frame 86
+// CHECK-DAG:  16. While in frame 85
+// CHECK-DAG:  17. While in frame 84
+// CHECK-DAG:  18. While in frame 83
+// CHECK-DAG:  19. While in frame 82
+// CHECK-DAG:  20. While in frame 81
+// CHECK-DAG:  21. While in frame 80
+// CHECK-DAG:  22. While in frame 79
+// CHECK-DAG:  23. While in frame 78
+// CHECK-DAG:  24. While in frame 77
+// CHECK-DAG:  25. While in frame 76
+// CHECK-DAG:  26. While in frame 75
+// CHECK-DAG:  27. While in frame 74
+// CHECK-DAG:  28. While in frame 73
+// CHECK-DAG:  29. While in frame 72
+// CHECK-DAG:  30. While in frame 71
+// CHECK-DAG:  31. While in frame 70
+// CHECK-DAG:  32. While in frame 69
+// CHECK-DAG:  33. While in frame 68
+// CHECK-DAG:  34. While in frame 67
+// CHECK-DAG:  35. While in frame 66
+// CHECK-DAG:  36. While in frame 65
+// CHECK-DAG:  37. While in frame 64
+// CHECK-DAG:  38. While in frame 63
+// CHECK-DAG:  39. While in frame 62
+// CHECK-DAG:  40. While in frame 61
+// CHECK-DAG:  41. While in frame 60
+// CHECK-DAG:  42. While in frame 59
+// CHECK-DAG:  43. While in frame 58
+// CHECK-DAG:  44. While in frame 57
+// CHECK-DAG:  45. While in frame 56
+// CHECK-DAG:  46. While in frame 55
+// CHECK-DAG:  47. While in frame 54
+// CHECK-DAG:  48. While in frame 53
+// CHECK-DAG:  49. While in frame 52
+// CHECK-DAG:  50. While in frame 51
+// CHECK-DAG:  51. While in frame 50
+// CHECK-DAG:  52. While in frame 49
+// CHECK-DAG:  53. While in frame 48
+// CHECK-DAG:  54. While in frame 47
+// CHECK-DAG:  55. While in frame 46
+// CHECK-DAG:  56. While in frame 45
+// CHECK-DAG:  57. While in frame 44
+// CHECK-DAG:  58. While in frame 43
+// CHECK-DAG:  59. While in frame 42
+// CHECK-DAG:  60. While in frame 41
+// CHECK-DAG:  61. While in frame 40
+// CHECK-DAG:  62. While in frame 39
+// CHECK-DAG:  63. While in frame 38
+// CHECK-DAG:  64. While in frame 37
+// CHECK-DAG:  65. While in frame 36
+// CHECK-DAG:  66. While in frame 35
+// CHECK-DAG:  67. While in frame 34
+// CHECK-DAG:  68. While in frame 33
+// CHECK-DAG:  69. While in frame 32
+// CHECK-DAG:  70. While in frame 31
+// CHECK-DAG:  71. While in frame 30
+// CHECK-DAG:  72. While in frame 29
+// CHECK-DAG:  73. While in frame 28
+// CHECK-DAG:  74. While in frame 27
+// CHECK-DAG:  75. While in frame 26
+// CHECK-DAG:  76. While in frame 25
+// CHECK-DAG:  77. While in frame 24
+// CHECK-DAG:  78. While in frame 23
+// CHECK-DAG:  79. While in frame 22
+// CHECK-DAG:  80. While in frame 21
+// CHECK-DAG:  81. While in frame 20
+// CHECK-DAG:  82. While in frame 19
+// CHECK-DAG:  83. While in frame 18
+// CHECK-DAG:  84. While in frame 17
+// CHECK-DAG:  85. While in frame 16
+// CHECK-DAG:  86. While in frame 15
+// CHECK-DAG:  87. While in frame 14
+// CHECK-DAG:  88. While in frame 13
+// CHECK-DAG:  89. While in frame 12
+// CHECK-DAG:  90. While in frame 11
+// CHECK-DAG:  91. While in frame 10
+// CHECK-DAG:  92. While in frame 9
+// CHECK-DAG:  93. While in frame 8
+// CHECK-DAG:  94. While in frame 7
+// CHECK-DAG:  95. While in frame 6
+// CHECK-DAG:  96. While in frame 5
+// CHECK-DAG:  97. While in frame 4
+// CHECK-DAG:  98. While in frame 3
+// CHECK-DAG:  99. While in frame 2
+// CHECK-DAG:  100. While in frame 1
+func buildTrace(_ int: Int = 1) {
+  if int > 100 { abort() }
+  trace("in frame \(int)") {
+    buildTrace(int + 1)
+  }
+}
+
+buildTrace()

--- a/Tests/nsexception.swift
+++ b/Tests/nsexception.swift
@@ -6,8 +6,8 @@ import Foundation
 // CHECK-DAG: about to raise!
 // CHECK-DAG: Terminating app due to uncaught exception 'NSGenericException', reason: 'You failed'
 // CHECK-DAG: Stack dump:
-// CHECK-DAG: -> While raising an exception
-// CHECK-DAG: -> While doing first task
+// CHECK-DAG:   1. While raising an exception
+// CHECK-DAG:   2. While doing first task
 trace("doing first task") {
   print("in first task!")
   trace("raising an exception") {

--- a/Tests/stack-overflow.swift
+++ b/Tests/stack-overflow.swift
@@ -8,8 +8,8 @@ func overflow() {
 // CHECK-DAG: in first task!
 // CHECK-DAG: in second task!
 // CHECK-DAG: Stack dump
-// CHECK-DAG: -> While doing second task
-// CHECK-DAG: -> While doing first task
+// CHECK-DAG:   1. While doing second task
+// CHECK-DAG:   2. While doing first task
 trace("doing first task") {
   print("in first task!")
   trace("doing second task") {


### PR DESCRIPTION
This patch adds stack indexes before each entry in the pretty stack trace, like so:

```
Stack dump:
  1. While raising an exception (func main, in file <stdin>, line 317)
  2. While doing first task (func main, in file <stdin>, line 315)
```

In this patch we have to be very careful to avoid any checked arithmetic expressions and be safe about allocations. The buffer containing this string is pre-allocated and leaked on program exit.

This function compiles to the following IR:

```llvm
define hidden swiftcc void @_T016PrettyStackTrace8writeIntySiF(i64) local_unnamed_addr #0 {
entry:
  %1 = icmp sgt i64 %0, 99999999
  br i1 %1, label %32, label %2

; <label>:2:                                      ; preds = %entry
  %3 = load %Ts4Int8V*, %Ts4Int8V** bitcast (%TSp* @_T016PrettyStackTrace12numberBufferSpys4Int8VGv to %Ts4Int8V**), align 8
  %4 = getelementptr inbounds %Ts4Int8V, %Ts4Int8V* %3, i64 10, i32 0
  %5 = icmp sgt i64 %0, 0
  br i1 %5, label %.preheader.preheader, label %.loopexit

.preheader.preheader:                             ; preds = %2
  br label %.preheader

.preheader:                                       ; preds = %.preheader.preheader, %13
  %6 = phi i64 [ %14, %13 ], [ %0, %.preheader.preheader ]
  %7 = phi i8* [ %15, %13 ], [ %4, %.preheader.preheader ]
  %8 = srem i64 %6, 10
  %9 = add nsw i64 %8, 48
  %10 = trunc i64 %9 to i8
  %11 = icmp slt i8 %10, 0
  %12 = icmp sgt i64 %9, 127
  %or.cond3 = and i1 %12, %11
  br i1 %or.cond3, label %34, label %13

; <label>:13:                                     ; preds = %.preheader
  %14 = sdiv i64 %6, 10
  store i8 %10, i8* %7, align 1
  %15 = getelementptr inbounds i8, i8* %7, i64 -1
  %16 = icmp sgt i64 %6, 9
  br i1 %16, label %.preheader, label %.loopexit.loopexit

.loopexit.loopexit:                               ; preds = %13
  br label %.loopexit

.loopexit:                                        ; preds = %.loopexit.loopexit, %2
  %17 = phi i8* [ %4, %2 ], [ %15, %.loopexit.loopexit ]
  store i8 32, i8* %17, align 1
  %18 = getelementptr inbounds i8, i8* %17, i64 -1
  store i8 32, i8* %18, align 1
  %19 = load %Ts4Int8V*, %Ts4Int8V** bitcast (%TSp* @_T016PrettyStackTrace12numberBufferSpys4Int8VGv to %Ts4Int8V**), align 8
  %20 = getelementptr inbounds %Ts4Int8V, %Ts4Int8V* %19, i64 13, i32 0
  %21 = ptrtoint i8* %18 to i64
  %22 = ptrtoint i8* %20 to i64
  %23 = sub i64 %21, %22
  %24 = icmp slt i64 %23, 0
  br i1 %24, label %25, label %29

; <label>:25:                                     ; preds = %.loopexit
  %26 = tail call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 0, i64 %23)
  %27 = extractvalue { i64, i1 } %26, 0
  %28 = extractvalue { i64, i1 } %26, 1
  br i1 %28, label %33, label %29

; <label>:29:                                     ; preds = %.loopexit, %25
  %30 = phi i64 [ %27, %25 ], [ %23, %.loopexit ]
  %31 = tail call i64 @"\01_write"(i32 2, i8* %18, i64 %30)
  br label %32

; <label>:32:                                     ; preds = %entry, %29
  ret void

; <label>:33:                                     ; preds = %25
  tail call void asm sideeffect "", "n"(i32 1) #15
  tail call void @llvm.trap()
  unreachable

; <label>:34:                                     ; preds = %.preheader
  tail call void asm sideeffect "", "n"(i32 4) #15
  tail call void @llvm.trap()
  unreachable
}
```

I know we shouldn't rely on the specific compilation details, but the stuff used in this function is not likely to change.